### PR TITLE
Improve documentation

### DIFF
--- a/src/options.adoc
+++ b/src/options.adoc
@@ -1,0 +1,248 @@
+// tag::strategyOptions[]
+
+// tag::strategy[]
+.strategy
+****
+*Type*: one of "MAVEN", "CONFIGURABLE", "PATTERN"
+
+*Default*: `"CONFIGURABLE"` (`"MAVEN"` if using the Maven plugin)
+
+Selects what strategy/mode to use jgitver in. CONFIGURABLE is generally referred to as the default unless specifically talking about Maven.
+****
+// end::strategy[]
+
+// tag::mavenLike[]
+.mavenLike (deprecated)
+****
+*Type*: boolean
+
+*Default*: `false`
+
+Deprecated in favor of setting the strategy. If `true`, equivalent to setting the MAVEN strategy.
+****
+// end::mavenLike[]
+
+// end::strategyOptions[]
+
+
+
+// tag::qualifierOptions[]
+
+// tag::nonQualifierBranches[]
+.nonQualifierBranches
+****
+*Type*: string (comma-separated list of branch names)
+
+*Default*: `"master"`
+
+Branches for which the version should not have a qualifier added.
+
+Setting this option replaces any configuration for the qualifierBranchingPolicies option.
+****
+// end::nonQualifierBranches[]
+
+// tag::qualifierBranchingPolicies[]
+.qualifierBranchingPolicies
+****
+*Type*: list of branch policies (configuration varies)
+
+*Default*: None
+
+Configuration of this option varies depending on your platform (Maven vs. Gradle).
+
+At a high-level, each branch policy is a combination of two things:
+
+1. *Pattern*, a regex string with a single capture group
+2. *Transformations*, a list of strings
+
+Valid transformations are below:
+
+- `"IDENTITY"` or `"REMOVE_UNEXPECTED_CHARS"`: removes whitespace, dashes, and slashes
+- `"REPLACE_UNEXPECTED_CHARS_UNDERSCORE"`: replaces whitespace, dashes, and slashes with underscores
+- `"UPPERCASE"`: all characters made uppercase with default Java locale
+- `"LOWERCASE"`: all characters made lowercase with default Java locale
+- `"UPPERCASE_EN"`: all characters made uppercase with Java English locale
+- `"LOWERCASE_EN"`: all characters made lowercase with Java English locale
+- `"IGNORE"`: do not use branch name as a qualifier
+
+If you define a branch policy with a pattern but don't specify any transformations,
+`"REPLACE_UNEXPECTED_CHARS_UNDERSCORE"` and `"LOWERCASE_EN"` will be used by default.
+
+See the configuration sections for more information on setting this option.
+****
+// end::qualifierBranchingPolicies[]
+
+// tag::useDefaultBranchingPolicy[]
+.useDefaultBranchingPolicy
+****
+*Type*: boolean
+
+*Default*: `true`
+
+If `true`, adds a default fallback branch policy behind any set by the qualifierBranchingPolicies option.
+
+The default fallback is as follows:
+
+- *Pattern*: `"(.*)"`
+- *Transformations*: `["REPLACE_UNEXPECTED_CHARS_UNDERSCORE", "LOWERCASE_EN"]`
+****
+// end::useDefaultBranchingPolicy[]
+
+// end::qualifierOptions[]
+
+
+
+// tag::gitQualifierOptions[]
+
+// tag::useDistance[]
+.useDistance
+****
+*Type*: boolean
+
+*Default*: `true`
+
+If `true`, add the distance between HEAD and the commit with the tag used to calculate a version as a qualifier.
+
+This is not used if the "SNAPSHOT" qualifier is added to the calculated version.
+****
+// end::useDistance[]
+
+// tag::useLongFormat[]
+.useLongFormat
+****
+*Type*: boolean
+
+*Default*: `false`
+
+If `true`, put a "g" before any git commit ID qualifiers to be compliant with the `git describe --long` format.
+****
+// end::useLongFormat[]
+
+// tag::useGitCommitId[]
+.useGitCommitId
+****
+*Type*: boolean
+
+*Default*: `false`
+
+If `true`, appends the SHA1 git commit ID as a qualifier.
+
+This is not used if the "SNAPSHOT" qualifier is added to the calculated version.
+****
+// end::useGitCommitId[]
+
+// tag::useGitCommitTimestamp[]
+.useGitCommitTimestamp
+****
+*Type*: boolean
+
+*Default*: `false`
+
+If `true`, appends the git commit timestamp as a qualifier.
+
+This is not used if the "SNAPSHOT" qualifier is added to the calculated version.
+****
+// end::useGitCommitTimestamp[]
+
+// tag::gitCommentIdLength[]
+.gitCommentIdLength
+****
+*Type*: int (between 8 and 40 inclusive)
+
+*Default*: `8`
+
+Sets the length of git commit IDs used as a qualifier by the useGitCommitId option.
+****
+// end::gitCommentIdLength[]
+
+// end::gitQualifierOptions[]
+
+
+
+// tag::generalOptions[]
+
+// tag::maxDepth[]
+.maxDepth
+****
+*Type*: int
+
+*Default*: `Integer.MAX_VALUE`
+
+Sets how many commits deep to look for tags to calculate the version from.
+****
+// end::maxDepth[]
+
+// tag::lookupPolicy[]
+.lookupPolicy
+****
+*Type*: one of "MAX", "LATEST", "NEAREST"
+
+*Default*: `"MAX"`
+
+Sets how tags should be used for calculating versions.
+****
+// end::lookupPolicy[]
+
+// tag::regexVersionTag[]
+.regexVersionTag
+****
+*Type*: string (regexp with at least one capture group)
+
+*Default*: `"v?([0-9]+(?:\\.[0-9]+){0,2}(?:-[a-zA-Z0-9\\-_]+)?)"`
+
+Defines how versions should be extracted from tags. The capture group should select the version to use for calculations.
+****
+// end::regexVersionTag[]
+
+// end::generalOptions[]
+
+
+
+// tag::autoIncrementPatch[]
+.autoIncrementPatch
+****
+*Type*: boolean
+
+*Default*: `false`
+
+If `true`, increment the patch version by one if the tag used to calculate a version was:
+
+- A normal, annotated one (not lightweight)
+- On some commit before HEAD (not on HEAD itself)
+
+This is not used if the "SNAPSHOT" qualifier is added to the calculated version.
+****
+// end::autoIncrementPatch[]
+
+// tag::useDirty[]
+.useDirty
+****
+*Type*: boolean
+
+*Default*: `false`
+
+If `true`, append "dirty" as a qualifier if the repository has uncommitted changes or new files.
+****
+// end::useDirty[]
+
+// tag::tagVersionPattern[]
+.tagVersionPattern
+****
+*Type*: string
+
+*Default*: `"${v}"`
+
+In the PATTERN strategy, define the version pattern to use the HEAD is on an annotated tag.
+****
+// end::tagVersionPattern[]
+
+// tag::versionPattern[]
+.versionPattern
+****
+*Type*: string
+
+*Default*: `"${v}${<meta.QUALIFIED_BRANCH_NAME}${<meta.COMMIT_DISTANCE}"`
+
+In the PATTERN strategy, define the version pattern to use by default (when HEAD is not on an annotated tag).
+****
+// end::versionPattern[]

--- a/src/user_documentation.adoc
+++ b/src/user_documentation.adoc
@@ -486,6 +486,7 @@ Eclipse will import it using the content of your pom.xml file, it will not evalu
 
 Unfortunately, Intellij IDEA still does not work out of the box when {jgitver-doc}[jgitver] is there.
 The problem has been reported to Intellij under the following issue https://youtrack.jetbrains.com/issue/IDEA-187928[IDEA-187928].
+Anecdotally, recent versions of IntelliJ have no problem with {jgitver-gradle-plugin}}[the Gradle plugin].
 
 To workaround Intellij failure, you have to deactivate {jgitver-doc}[jgitver] for the import step.
 For maven projects for example, open the settings `CTRL+ALT+S` and modify imports settings by adding `-Djgitver.skip=true`

--- a/src/user_documentation.adoc
+++ b/src/user_documentation.adoc
@@ -240,17 +240,231 @@ Same as above but using the "`~`" prefix to optionally apply the hyphen:
 
 == Maven configuration
 
-include::includes.adoc[tag=wip]
+=== Configuration file
 
-see the https://github.com/jgitver/jgitver-maven-plugin[jgitver-maven-plugin] project
-https://github.com/jgitver/jgitver-maven-plugin/blob/master/README.md[README] until the doc is enhanced.
+{jgitver-maven-plugin}[Jgitver's Maven] configuration file may be placed at `$rootProjectDir/.mvn/jgitver.config.xml`.
+
+The file should be compliant with the latest schema (given in the https://github.com/jack-r-warren/jgitver-maven-plugin/blob/master/README.md[README]). An example is below.
+
+The file as given is the default, if a value isn't provided it is because there isn't a default. All settings are optional.
+
+[source,xml]
+.jgitver.config.xml
+----
+<configuration xmlns="http://jgitver.github.io/maven/configuration/1.1.0"
+	    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	    xsi:schemaLocation="http://jgitver.github.io/maven/configuration/1.1.0 https://jgitver.github.io/maven/configuration/jgitver-configuration-v1_1_0.xsd">
+
+    <!-- One of MAVEN, CONFIGURABLE, PATTERN -->
+    <strategy>MAVEN</strategy>
+
+    <!-- Deprecated (this field replaced and overridden by strategy), boolean -->
+    <mavenLike>true</mavenLike>
+
+    <!-- One of MAX, LATEST, NEAREST -->
+    <policy>MAX</policy>
+
+    <!-- Boolean -->
+    <autoIncrementPatch>true</autoIncrementPatch>
+
+    <!-- Boolean -->
+    <useCommitDistance>true</useCommitDistance>
+
+    <!-- Boolean -->
+    <useDirty>false</useDirty>
+
+    <!-- Boolean -->
+    <useGitCommitId>false</useGitCommitId>
+
+    <!-- Integer between 8 and 40 inclusive -->
+    <gitCommitIdLength>8</gitCommitIdLength>
+
+    <!-- Integer -->
+    <maxSearchDepth>Integer.MAX_VALUE</maxSearchDepth>
+
+    <!-- String, comma separate multiple branches -->
+    <nonQualifierBranches>master</nonQualifierBranches>
+
+    <!-- An optional list of directories to not assign Jgitver's version for -->
+    <exclusions>
+        <!-- String, relative path from project root -->
+        <exclusion></exclusion>
+    </exclusions>
+
+    <!-- Boolean -->
+    <useDefaultBranchingPolicy>true</useDefaultBranchingPolicy>
+
+    <!-- String, only for PATTERN strategy" -->
+    <versionPattern>${v}${&lt;meta.QUALIFIED_BRANCH_NAME}${&lt;meta.COMMIT_DISTANCE}</versionPattern>
+    <!-- Usages of "<" are escaped with "&lt;" -->
+
+    <!-- String, only for PATTERN strategy -->
+    <tagVersionPattern>${v}</tagVersionPattern>
+
+    <branchPolicies>
+        <branchPolicy>
+            <!-- String, regex with one capture group -->
+            <pattern></pattern>
+            <transformations>
+                <!-- String, a name of a transformation -->
+                <transformation>REPLACE_UNEXPECTED_CHARS_UNDERSCORE</transformation>
+                <transformation>LOWERCASE_EN</transformation>
+            </transformations>
+        </branchPolicy>
+    </branchPolicies>
+
+    <!-- String, regex with at least one capture group -->
+    <regexVersionTag>v?([0-9]+(?:\\.[0-9]+){0,2}(?:-[a-zA-Z0-9\\-_]+)?)</regexVersionTag>
+</configuration>
+----
+
+The branch policy is a list so that it may represent policies for different patterns. For example:
+
+[source,xml]
+----
+<configuration xmlns="http://jgitver.github.io/maven/configuration/1.1.0"
+	    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	    xsi:schemaLocation="http://jgitver.github.io/maven/configuration/1.1.0 https://jgitver.github.io/maven/configuration/jgitver-configuration-v1_1_0.xsd">
+    <branchPolicies>
+        <branchPolicy>
+            <pattern>feature_(.*)</pattern>
+            <transformations>
+                <transformation>REMOVE_UNEXPECTED_CHARS</transformation>
+                <transformation>UPPERCASE</transformation>
+            </transformations>
+        </branchPolicy>
+        <branchPolicy>
+            <pattern>(master)</pattern>
+            <transformations>
+                <transformation>IGNORE</transformation>
+            </transformations>
+        </branchPolicy>
+    </branchPolicies>
+</configuration>
+----
+
+For more information on all of the different options, see the configuration options for your chosen <<Modes, mode>>.
 
 == Gradle configuration
 
-include::includes.adoc[tag=wip]
+[NOTE]
+====
+Configuration of the https://github.com/jgitver/gradle-jgitver-plugin[gradle-jgitver-plugin] is only supported in plugin versions above 0.2.0.
 
-see the https://github.com/jgitver/gradle-jgitver-plugin[gradle-jgitver-plugin] project
-https://github.com/jgitver/gradle-jgitver-plugin/blob/master/README.md[README] until the doc is enhanced.
+Information on behavior before that point is available in the https://github.com/jgitver/gradle-jgitver-plugin/blob/master/README.md#version--020-1[README].
+====
+
+=== Configuration block
+
+{jgitver-gradle-plugin}[Jgitver's Gradle] configuration block is as follows.
+
+The block as given is the default, if a value is missing it is because none is provided by default. All settings are optional.
+
+[source,groovy]
+.build.gradle
+----
+jgitver {
+    // One of 'MAVEN', 'CONFIGURABLE', 'PATTERN'
+    strategy 'CONFIGURABLE'
+
+    // Deprecated (use strategy instead), boolean
+    mavenLike false
+
+    // One of 'MAX', 'LATEST', 'NEAREST'
+    policy 'MAX'
+
+    // Boolean
+    autoIncrementPatch true
+
+    // Boolean
+    useDistance true
+
+    // Boolean
+    useDirty false
+
+    // Boolean
+    failIfDirty false
+
+    // Boolean
+    useGitCommitTimestamp false
+
+    // Boolean
+    useGitCommitID false
+
+    // Integer between 8 and 40 inclusive
+    gitCommitIDLength 8
+
+    // Since plugin version 0.7.0, integer
+    maxDepth Integer.MAX_VALUE
+
+    // String, comma separate multiple branches
+    nonQualifierBranches 'master'
+
+    // Since plugin version 0.6.0, string, only for PATTERN strategy
+    versionPattern '${v}${<meta.QUALIFIED_BRANCH_NAME}${<meta.COMMIT_DISTANCE}'
+
+    // Since plugin version 0.6.0, string, only for PATTERN strategy
+    tagVersionPattern '${v}'
+
+    // Closure, can be set multiple times
+    policy {
+        // String, regex with one capture group
+        pattern =
+        // Array of strings, each being a transformation
+        transformations = ['REPLACE_UNEXPECTED_CHARS_UNDERSCORE', 'LOWERCASE_EN']
+    }
+
+    // One of 'FIRST_PARENT', 'LOG', 'DEPTH'
+    distanceCalculatorKind 'FIRST_PARENT'
+
+    // String, regex with at least one capture group
+    regexVersionTag 'v?([0-9]+(?:\\.[0-9]+){0,2}(?:-[a-zA-Z0-9\\-_]+)?)'
+}
+----
+
+The branch policy can be set multiple times to set policies for different patterns. For example:
+
+[source,groovy]
+----
+jgitver {
+    policy {
+		pattern = 'feature_(.*)'
+		transformations = ['REMOVE_UNEXPECTED_CHARS', 'UPPERCASE']
+	}
+    policy {
+		pattern = '(master)'
+		transformations = ['IGNORE']
+	}
+}
+----
+
+For more information on all of the different options, see the configuration options for your chosen <<Modes, mode>>.
+
+=== Multi-project builds
+
+In a https://guides.gradle.org/creating-multi-project-builds/[multi-project] build, {jgitver-doc}[jgitver] can be enabled and globally for all projects.
+Assuming that the root project and all sub-projects are in the same repository, this will keep their versions perfectly in sync.
+
+Configuration is done in the root project's build.gradle:
+
+[source,groovy]
+.build.gradle
+----
+// Define plugin here (only actually applies the plugin in the root project)
+plugins {
+    id "fr.brouillard.oss.gradle.jgitver" version "0.9.1"
+}
+
+allprojects {
+
+    // Ensure plugin is applied in all projects
+    apply plugin: 'fr.brouillard.oss.gradle.jgitver'
+
+    jgitver {
+        // Your config goes here
+    }
+}
+----
 
 == IDEs usage
 

--- a/src/user_documentation.adoc
+++ b/src/user_documentation.adoc
@@ -9,6 +9,17 @@ see the <<developer_documentation.adoc#_projects,projects>> section to access ex
 
 {jgitver-doc}[jgitver] provides different ways of computing version called _'modes'_ or _'strategies'_. Each mode comes with some behavior, defaults and configuration capabilities.
 
+Each of the modes has their own options. Those options are detailed in the configuration section of each of the mode sections below.
+
+The mode itself is set via the strategy option:
+
++++ <details><summary> +++
+*_Click for configuration options_*
++++ </summary><div> +++
+
+include::options.adoc[tag=strategyOptions]
++++ </div></details> +++
+
 === maven mode
 
 [TIP]
@@ -26,6 +37,13 @@ In this mode _(which is the default mode of the jgitver maven plugin)_, {jgitver
 - use lightweight tags before annotated ones when on a normal branch (master or any other branch) : _start 'next' version after release_
 - add a branch qualifier on purpose : _avoid version collision for feature branches_
 
++++ <details><summary> +++
+*_Click for configuration options_*
++++ </summary><div> +++
+
+include::options.adoc[tags=qualifierOptions;generalOptions;useDirty]
++++ </div></details> +++
+
 === default mode
 
 [TIP]
@@ -41,6 +59,13 @@ In this mode _(which is the default mode of the jgitver gradle plugin)_, {jgitve
   - exception is when HEAD is on current branch, lightweight tags have precedence only when the repository is dirty
 * add a branch qualifier on purpose
 
++++ <details><summary> +++
+*_Click for configuration options_*
++++ </summary><div> +++
+
+include::options.adoc[tags=qualifierOptions;generalOptions;gitQualifierOptions;useDirty;autoIncrementPatch]
++++ </div></details> +++
+
 === pattern mode
 
 [TIP]
@@ -53,12 +78,165 @@ This mode allows some freedom to the project owner. As a project maintainer you 
 The pattern mode is new in jgitver-0.7.0 and is to be considered as beta feature.
 ====
 
-In this mode, {jgitver-lib}[jgitver] computes some metadatas that can be used in a pattern definition, provided by configuration, to compute the final version.
+In this mode, {jgitver-lib}[jgitver] computes some metadatas that can be used in a pattern definition to compute the final version.
 
-[NOTE]
-====
-this section needs enhancements. Partial information can be found in https://github.com/jgitver/jgitver/issues/33#issuecomment-350811654[jgitver#33].
-====
+These pattern definitions are given as configuration options and should follow the grammar below.
+
++++ <details><summary> +++
+*_Click for configuration options_*
++++ </summary><div> +++
+
+include::options.adoc[tags=tagVersionPattern;versionPattern;qualifierOptions;maxDepth;autoIncrementPatch]
++++ </div></details> +++
+
+==== Pattern grammar
+
+* A `_pattern_` consists of at least one `_pattern element_`, one after another
+* A `_pattern element_` is either arbitrary characters or a `_delimited placeholder_`
+** Arbitrary characters include letters, digits, or any of the four symbols "`_-.+`"
+* A `_delimited placeholder_` is "`${`", followed by a `_placeholder_`, followed by "`}`"
+* A `_placeholder_` is an `_inner placeholder_`, possibly with a `_prefix_` before it
+* A `_prefix_` is one of any of the following:
+** Arbitrary characters followed by "`:`" means the characters will always appear before the `_inner placeholder_`, even if it empty
+** Arbitrary characters followed by "`~`" means the characters will appear before the `_inner placeholder_` if it is not empty
+** "`<`" automatically applies a separator (hyphen between qualifier and version, period between qualifiers) to conform with strict https://semver.org/[semver rules]
+* An `_inner placeholder_` is one of any of the following:
+** "`v`", which will be replaced with the full calculated version number (major.minor.patch)
+** "`M`", which will be replaced with the calculated major version number
+** "`m`", which will be replaced with the calculated minor version number
+** "`p`", which will be replaced with the calculated patch version number
+** "`sys.`" followed by arbitrary characters, which will be replaced with accessing that system property (via Java's `System.getProperty`)
+** "`env.`" followed by arbitrary characters, which will be replaced with accessing that environment variable (via Java's `System.getenv`)
+** "`meta.`" followed by arbitrary characters, which will be replaced with accessing that meta field
+
+==== Meta fields
+
+|===
+|Name |Description
+
+|"`CALCULATED_VERSION`"
+|The calculated version
+
+|"`DIRTY`"
+|Is the repository dirty
+
+|"`HEAD_COMMITTER_NAME`"
+|Name of the commiter of HEAD commit
+
+|"`HEAD_COMMITER_EMAIL`"
+|Email of the commiter of HEAD commit
+
+|"`HEAD_COMMIT_DATETIME`"
+|Datetime of the commit
+
+|"`GIT_SHA1_FULL`"
+|Corresponds to then the full git identifier of the HEAD
+
+|"`GIT_SHA1_8`"
+|Corresponds to a substring of the git identifier of the HEAD
+
+|"`BRANCH_NAME`"
+|Corresponds to the current branch name if any
+
+|"`QUALIFIED_BRANCH_NAME`"
+|Branch name used as a qualifier if any
+
+|"`HEAD_TAGS`"
+|Corresponds to the list of tags, associated with the current HEAD
+
+|"`HEAD_ANNOTATED_TAGS`"
+|Corresponds to the list of annotated tags, associated with the current HEAD
+
+|"`HEAD_LIGHTWEIGHT_TAGS`"
+|Corresponds to the list of light tags, associated with the current HEAD
+
+|"`HEAD_VERSION_TAGS`"
+|Corresponds to the list of tags, eligible as version, associated with the current HEAD
+
+|"`HEAD_VERSION_ANNOTATED_TAGS`"
+|Corresponds to the list of annotated tags, eligible as version, associated with the current HEAD
+
+|"`HEAD_VERSION_LIGHTWEIGHT_TAGS`"
+|Corresponds to the list of light tags, eligible as version, associated with the current HEAD
+
+|"`BASE_TAG`"
+|Corresponds to the base tag that was used for the version calculation
+
+|"`BASE_TAG_TYPE`"
+|Corresponds to the type of tag that was used for the version calculation
+
+|"`ALL_TAGS`"
+|Corresponds to the whole list of tags of the current repository
+
+|"`ALL_ANNOTATED_TAGS`"
+|Corresponds to the whole list of annotated tags of the current repository
+
+|"`ALL_LIGHTWEIGHT_TAGS`"
+|Corresponds to the whole list of light tags of the current repository
+
+|"`ALL_VERSION_TAGS`"
+|Corresponds to the whole list of tags that can serve for version calculation
+
+|"`ALL_VERSION_ANNOTATED_TAGS`"
+|Corresponds to the whole list of annotated tags of the current repository that can serve for version calculation
+
+|"`ALL_VERSION_LIGHTWEIGHT_TAGS`"
+|Corresponds to the whole list of light tags of the current repository that can serve for version calculation
+
+|"`NEXT_MAJOR_VERSION`"
+|Exposes the next calculated version by adding one to the major digit of the current retained version
+
+|"`NEXT_MINOR_VERSION`"
+|Exposes the next calculated version by adding one to the minor digit of the current retained version
+
+|"`NEXT_PATCH_VERSION`"
+|Exposes the next calculated version by adding one to the patch digit of the current retained version
+
+|"`BASE_VERSION`"
+|Exposes the version used to base the calculation on for the retained version
+
+|"`CURRENT_VERSION_MAJOR`"
+|Exposes the major version of the computed version, ie the X in X.Y.Z
+
+|"`CURRENT_VERSION_MINOR`"
+|Exposes the minor version of the computed version, ie the Y in X.Y.Z
+
+|"`CURRENT_VERSION_PATCH`"
+|Exposes the patch version of the computed version, ie the Z in X.Y.Z
+
+|"`COMMIT_DISTANCE`"
+|Exposes the commit distance from the base tag used for the version computation
+
+|"`COMMIT_TIMESTAMP`"
+|Exposes the commit timestamp instant in the current system timezone using a simplified DateTimeFormatter.ISO_LOCAL_DATE_TIME
+|===
+
+==== Examples
+
+As a simple example, the following patterns produce equivalent output:
+
+* "`${v}`"
+* "`${M}.${m}.${p}`"
+* "`${meta.CALCULATED_VERSION}`"
+
+The following pattern substitutes the commit distance for the patch number:
+
+* "`${M}.${m}.${meta.COMMIT_DISTANCE}"
+
+The following pattern appends the branch name and git commit ID as a qualifier, using the "`<`" prefix to use periods after the first hyphen:
+
+* "`${v}${<meta.QUALIFIED_BRANCH_NAME}${<meta.GIT_SHA1_8}`" might produce "1.2.3-develop.a1b2c3d4"
+
+The following pattern appends the value of an environment variable "FOO" to the version, and always adds a hyphen even if it is empty with the "`:`" prefix:
+
+* "`${v}${-:env.FOO}`" might produce "1.2.3-bar" if the "FOO" environment variable contains "bar"
+* "`${v}${-:env.FOO}`" might produce "1.2.3-" if the "FOO" environment variable is empty
+
+Same as above but using the "`~`" prefix to optionally apply the hyphen:
+
+* "`${v}${-~env.FOO}`" might produce "1.2.3-bar" if the "FOO" environment variable contains "bar"
+* "`${v}${-~env.FOO}`" might produce "1.2.3" if the "FOO" environment variable is empty
+
 
 == Maven configuration
 


### PR DESCRIPTION
- Add documentation for the options provided by Jgitver itself (from fr.brouillard.oss.jgitver.GitVersionCalculator, drawing defaults from its Impl class)
  - Used HTML \<details> to not clog up the page, click and the options drop down
  - Added docs on the PATTERN mode as best as I could glean from its implementation in fr.brouillard.oss.jgitver.impl.pattern.VersionGrammarDefinition
- Add configuration examples for both Maven and Gradle (the examples are meant to be equivalent to the default configurations where possible)
- Add a note about IntelliJ not having problems with Gradle and Jgitver

More than happy for feedback. My asciidoc parser complains about the Maven config file example because I used empty elements where there isn't a default value to put there and because the schema doesn't allow the maxSearchDepth element that the plugin itself does.